### PR TITLE
Forward SSH_AUTH_SOCK to container

### DIFF
--- a/git-command-template
+++ b/git-command-template
@@ -4,5 +4,8 @@ GIT_DOCKER_ID=
 [[ ":$PATH:" != *":$DOCKER_BIN_PATH:"* ]] && PATH="$PATH:$DOCKER_BIN_PATH"
 
 git() {
-  (docker run -ti --rm -v "$HOME":/root -v "$PWD":/git "$GIT_DOCKER_ID" "$@")
+  (
+    [ -n "$SSH_AUTH_SOCK" ] && EXTRA_ARGS="-e SSH_AUTH_SOCK=$SSH_AUTH_SOCK -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK:ro"
+    docker run -ti --rm $EXTRA_ARGS -v "$HOME":/root -v "$PWD":/git "$GIT_DOCKER_ID" "$@"
+  )
 }


### PR DESCRIPTION
Bind-mount SSH_AUTH_SOCK so forwarded identities from a remote host can be used with git.