### PR TITLE
Add hadolint checks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,10 @@ repos:
     hooks:
       - id: beautysh
         args: ["-i", "2"]
+  - repo: https://github.com/AleksaC/hadolint-py
+    rev: v2.12.0.3
+    hooks:
+      - id: hadolint
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.14.0
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM alpine
+FROM alpine:3.19
 LABEL maintainer="Jannik Schäfer"
 
-RUN apk --update add git openssh && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm /var/cache/apk/*
+RUN apk --no-cache add git~=2.43 openssh~=9.6 && rm -rf /var/lib/apt/lists/* && rm /var/cache/apk/*
 
 VOLUME /git
 WORKDIR /git


### PR DESCRIPTION
This adds [hadolint](https://github.com/hadolint/hadolint) checks to the pre-commit.ci checks via the wrapper [AleksaC/hadolint-py](https://github.com/AleksaC/hadolint-py).
