### PR TITLE
Fix docker build when trying to remove apk cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.19
 LABEL maintainer="Jannik Schäfer"
 
-RUN apk --no-cache add git~=2.43 openssh~=9.6 && rm -rf /var/lib/apt/lists/* && rm /var/cache/apk/*
+RUN apk --no-cache add git~=2.43 openssh~=9.6 && rm -rf /var/lib/apt/lists/*
 
 VOLUME /git
 WORKDIR /git


### PR DESCRIPTION
A previous commit that added the '--no-cache' parameter to apk made apk
not create a cache anymore. Trying to remove the cache directory (and
content) then lead to a failure during docker build.
