### PR TITLE
Avoid adding ~/.local/bin to PATH in .profile if already set

### DIFF
--- a/install-git.sh
+++ b/install-git.sh
@@ -191,8 +191,8 @@ install_git_command() {
 #   None
 #######################################
 update_profile() {
-  local export_local_bin_path_line="export PATH=\"\$HOME/.local/bin:\$PATH\""
-  grep -qxF "$export_local_bin_path_line" "$PROFILE_PATH" &>/dev/null || echo "$export_local_bin_path_line" >>"$PROFILE_PATH"
+  local local_bin_path_line="PATH=\"\$HOME/.local/bin:\$PATH\""
+  grep -qF "$local_bin_path_line" "$PROFILE_PATH" &>/dev/null || echo -e "\n$local_bin_path_line" >>"$PROFILE_PATH"
 }
 
 main


### PR DESCRIPTION
This is mostly nitpicking: I already had a statement in my ~/.profile that added $HOME/.local/bin to the PATH.

The suggested change omits `export`ing PATH which is usually done in /etc/profile already, and will tolerate indentations as well when checking for an existing statement.