### PR TITLE
Passthrough HOME variable to allow access to config files

### DIFF
--- a/git
+++ b/git
@@ -4,7 +4,6 @@
 
 set -euo pipefail
 
-readonly CONTAINER_HOME="/root"
 readonly USER_CONFIG_PATHS=".gitconfig .git-credentials .config/git/ .ssh/"
 
 readonly container_image="${IMAGE_NAME:-alpine/git}:${IMAGE_TAG:-latest}"
@@ -31,7 +30,7 @@ config_volumes=""
 for path in $USER_CONFIG_PATHS; do
   home_path="$HOME/$path"
   if [[ -f "$home_path" || -d "$home_path" ]]; then
-    config_volumes="$config_volumes --volume $home_path:$CONTAINER_HOME/$path:ro"
+    config_volumes="$config_volumes --volume $home_path:$home_path:rw"
   fi
 done
 
@@ -42,6 +41,7 @@ done
   --rm \
   $interactive \
   $tty \
+  --env HOME=$HOME \
   --user "$(id -u):$(id -g)" \
   --workdir "$PWD" \
   --volume "$PWD:$PWD" \


### PR DESCRIPTION
By passing `--user "$(id -u):$(id -g)"` to the `docker run` command, the Git call runs under the user's ID and group. This is necessary to match the user and group for the Git repository path the the user operates on.

However, this introduces a mismatch between the container's home directory (defaults to `/root`) and passed-through config paths such as `/home/<user>/.gitconfig` etc.

By overriding `HOME` with the actual user's `HOME` variable, this mismatch is fixed.

This command did not work anymore:

```bash
# Calling the Git wrapper command
./git config --global user.name
```

This would output an empty value.

This PR also sets config paths to **read/write**, making it possible to use the Git wrapper command to also **set** config parameters.